### PR TITLE
Correct display bug in the demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <link rel="stylesheet" type="text/css" href="dist/calendar-heatmap.min.css">
 </head>
 <body>
+  
+  <div id="calendar"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js" charset="utf-8"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.10.2/d3.min.js" charset="utf-8"></script>
@@ -38,6 +40,9 @@
           }
         }.init();
       });
+      
+      // Set the div target id
+      var div_id = 'calendar';
 
       // Set custom color for the calendar heatmap
       var color = '#cd2327';
@@ -51,7 +56,7 @@
       };
 
       // Initialize calendar heatmap
-      calendarHeatmap.init(example_data, color, overview, print);
+      calendarHeatmap.init(example_data, div_id, color, overview, print);
     })();
   </script>
 </body>


### PR DESCRIPTION
I made a small adjustement locally to get a working demo. 

The heatmap was not showing because of an error in the argument order of the init() function. The argument ``container`` was missing.
https://github.com/g1eb/calendar-heatmap/blob/e32eecc24da21a43d8d8e2ccee9bf4baac25ac3e/index.html#L54 
https://github.com/g1eb/calendar-heatmap/blob/e32eecc24da21a43d8d8e2ccee9bf4baac25ac3e/src/calendar-heatmap.js#L24